### PR TITLE
Refactor test cases for new runner

### DIFF
--- a/terraform/test_example.rego
+++ b/terraform/test_example.rego
@@ -3,26 +3,19 @@ package terraform.test.example
 import data.terraform.example
 import data.terraform.inputs
 
-test_name = {"small_create", "large_create", "mix"}
-
-failure[x] {
-    test_name[x]
-    not success[x]
-}
-
-success["small_create"] {
+test_small_create {
     i = inputs.lineage0
     example.authz = true with input as i
     example.score = 11 with input as i
 }
 
-success["large_create"] {
+test_large_create {
     i = inputs.large_create
     example.authz = false with input as i
     example.score = 31 with input as i
 }
 
-success["mix"] {
+test_mix {
     i = inputs.lineage1
     example.authz = true with input as i
     example.score = 12 with input as i

--- a/terraform/test_library.rego
+++ b/terraform/test_library.rego
@@ -3,27 +3,20 @@ package terraform.test.library
 import data.terraform.library
 import data.terraform.inputs
 
-test_name = {"small_create", "large_create", "mix", "small_create_by_type", "mix_by_type", "large_create_by_type"}
-
-failure[x] {
-    test_name[x]
-    not success[x]
-}
-
-success["small_create"] {
+test_small_create {
     i = inputs.lineage0
     library.num_creates = 3 with input as i
     library.num_deletes = 0 with input as i
     library.num_modifies = 0 with input as i
 }
 
-success["resource_types"] {
+test_resource_types {
     i = inputs.lineage0
     x = library.resource_types with input as i
     x = {"aws_autoscaling_group", "aws_instance", "aws_launch_configuration"}
 }
 
-success["small_create_by_type"] {
+test_small_create_by_type {
     true
     i = inputs.lineage0
     library.num_creates_of_type["aws_instance"] = 1 with input as i
@@ -33,28 +26,28 @@ success["small_create_by_type"] {
     not has_non_zero_value(library.num_modifies_by_type, true) with input as i
 }
 
-success["mix"] {
+test_mix {
     i = inputs.lineage1
     library.num_creates = 1 with input as i
     library.num_deletes = 1 with input as i
     library.num_modifies = 1 with input as i
 }
 
-success["mix_by_type"] {
+test_mix_by_type {
     i = inputs.lineage1
     library.num_creates_of_type["aws_instance"] = 1 with input as i
     library.num_modifies_of_type["aws_autoscaling_group"] = 1 with input as i
     library.num_deletes_of_type["aws_instance"] = 1 with input as i
 }
 
-success["large_create"] {
+test_large_create {
     i = inputs.large_create
     library.num_creates = 5 with input as i
     library.num_deletes = 0 with input as i
     library.num_modifies = 0 with input as i
 }
 
-success["large_create_by_type"] {
+test_large_create_by_type {
     i = inputs.large_create
     library.num_creates_of_type["aws_instance"] = 1 with input as i
     library.num_creates_of_type["aws_autoscaling_group"] = 3 with input as i


### PR DESCRIPTION
The test runner in OPA will auto-discover test rules prefixed with
test_.