### PR TITLE
Adds an implementation of a kubernetes validating and mutating admission controller.

### DIFF
--- a/kubernetes/mutating-admission/README.md
+++ b/kubernetes/mutating-admission/README.md
@@ -4,3 +4,10 @@
 
 It was based on the existing examples at [Kubernetes Admission Control](https://www.openpolicyagent.org/docs/kubernetes-admission-control.html) and [MutatingAdmissionWebhook Example with OPA](https://gist.github.com/tsandall/a9b2b57f7c6768f49b25271776b72dee).
 
+## A note about labels and annotationsd
+
+When adding a label or annotation to some object's metadata Kubernetes requires that the `.../metadata/labels` or `.../metadata/annotations` node exists. The patch framework manages this through the `ensureParentPathsExist()` function, which will create the base `labels` or `annotations` nodes where required.
+
+## Helper functions
+
+A common use case for mutating admission controllers is adding or modifying labels and annotations, so a small set of helper functions is provided to aid readability. See `example_mutation.reg` for some examples.

--- a/kubernetes/mutating-admission/README.md
+++ b/kubernetes/mutating-admission/README.md
@@ -1,0 +1,6 @@
+# Validating + Mutating Kubernetes Admission Controller in pure Rego
+
+`main.rego` implements a simple framework that combines both validating and mutating admission controller rules, as well as some common helpers for working with labels and annotations.
+
+It was based on the existing examples at [Kubernetes Admission Control](https://www.openpolicyagent.org/docs/kubernetes-admission-control.html) and [MutatingAdmissionWebhook Example with OPA](https://gist.github.com/tsandall/a9b2b57f7c6768f49b25271776b72dee).
+

--- a/kubernetes/mutating-admission/data_kubernetes.rego
+++ b/kubernetes/mutating-admission/data_kubernetes.rego
@@ -1,0 +1,589 @@
+package library.kubernetes.admission.mutating.test
+
+request_default = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {""},
+}
+
+# Using a CRD for a resource called Dog, with a CRD definition as follows:
+# apiVersion: apiextensions.k8s.io/v1beta1
+# kind: CustomResourceDefinition
+# metadata:
+#   name: dogs.frens.teq0.com
+# spec:
+#   group: frens.teq0.com
+#   versions:
+#     - name: v1
+#       served: true
+#       storage: true
+#   version: v1
+#   scope: Cluster
+#   names:
+#     plural: dogs
+#     singular: dog
+#     kind: Dog
+#     shortNames:
+#     - dogue
+#   validation:
+#     openAPIV3Schema:
+#       properties:
+#         spec:
+#           properties:
+#             name:
+#               type: string
+#             isGood:
+#               type: boolean
+#             food:
+#               type: string
+
+request_dog_good = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {
+		"uid": "836c0cc6-096c-11e9-9a47-080027f60d22",
+		"kind": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"kind": "Dog",
+		},
+		"resource": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"resource": "dogs",
+		},
+		"name": "spike",
+		"operation": "UPDATE",
+		"userInfo": {
+			"username": "minikube-user",
+			"groups": [
+				"system:masters",
+				"system:authenticated",
+			],
+		},
+		"object": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"frens.teq0.com/v1\",\"kind\":\"Dog\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar1\"},\"name\":\"rex\",\"namespace\":\"\"},\"spec\":{\"food\":\"meat\",\"isGood\":false,\"name\":\"Rex\"}}\n"},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"labels": {"foo": "bar"},
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": true,
+				"name": "Spike",
+			},
+		},
+		"oldObject": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"frens.teq0.com/v1\",\"kind\":\"Dog\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar1\"},\"name\":\"rex\",\"namespace\":\"\"},\"spec\":{\"food\":\"meat\",\"isGood\":false,\"name\":\"Rex\"}}\n"},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"labels": {"foo": "bar1"},
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": false,
+				"name": "Spike",
+			},
+		},
+		"dryRun": false,
+	},
+}
+
+request_dog_some_labels_and_annotations = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {
+		"uid": "836c0cc6-096c-11e9-9a47-080027f60d22",
+		"kind": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"kind": "Dog",
+		},
+		"resource": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"resource": "dogs",
+		},
+		"name": "spike",
+		"operation": "UPDATE",
+		"userInfo": {
+			"username": "minikube-user",
+			"groups": [
+				"system:masters",
+				"system:authenticated",
+			],
+		},
+		"object": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {
+					"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"frens.teq0.com/v1\",\"kind\":\"Dog\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar1\"},\"name\":\"rex\",\"namespace\":\"\"},\"spec\":{\"food\":\"meat\",\"isGood\":false,\"name\":\"Rex\"}}\n",
+					"allthethings": "automate",
+				},
+				"labels": {
+					"gamma-rays": "on",
+					"yobba-rays": "on",
+					"moar-labels": "pleez",
+				},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": true,
+				"name": "Spike",
+			},
+		},
+		"oldObject": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"frens.teq0.com/v1\",\"kind\":\"Dog\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar1\"},\"name\":\"rex\",\"namespace\":\"\"},\"spec\":{\"food\":\"meat\",\"isGood\":false,\"name\":\"Rex\"}}\n"},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": false,
+				"name": "Spike",
+			},
+		},
+		"dryRun": false,
+	},
+}
+
+request_dog_existing_labels_and_annotations = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {
+		"uid": "836c0cc6-096c-11e9-9a47-080027f60d22",
+		"kind": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"kind": "Dog",
+		},
+		"resource": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"resource": "dogs",
+		},
+		"name": "spike",
+		"operation": "UPDATE",
+		"userInfo": {
+			"username": "minikube-user",
+			"groups": [
+				"system:masters",
+				"system:authenticated",
+			],
+		},
+		"object": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {"rating": "14/10"},
+				"labels": {
+					"foo": "bar",
+					"quuz": "corge",
+				},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": true,
+				"name": "Spike",
+			},
+		},
+		"oldObject": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"frens.teq0.com/v1\",\"kind\":\"Dog\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar1\"},\"name\":\"rex\",\"namespace\":\"\"},\"spec\":{\"food\":\"meat\",\"isGood\":false,\"name\":\"Rex\"}}\n"},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": false,
+				"name": "Spike",
+			},
+		},
+		"dryRun": false,
+	},
+}
+
+request_dog_no_labels_or_annotations = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {
+		"uid": "836c0cc6-096c-11e9-9a47-080027f60d22",
+		"kind": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"kind": "Dog",
+		},
+		"resource": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"resource": "dogs",
+		},
+		"name": "spike",
+		"operation": "UPDATE",
+		"userInfo": {
+			"username": "minikube-user",
+			"groups": [
+				"system:masters",
+				"system:authenticated",
+			],
+		},
+		"object": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": true,
+				"name": "Spike",
+			},
+		},
+		"oldObject": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"name": "spike",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": false,
+				"name": "Spike",
+			},
+		},
+		"dryRun": false,
+	},
+}
+
+request_dog_bad = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {
+		"uid": "836c0cc6-096c-11e9-9a47-080027f60d22",
+		"kind": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"kind": "Dog",
+		},
+		"resource": {
+			"group": "frens.teq0.com",
+			"version": "v1",
+			"resource": "dogs",
+		},
+		"name": "rex",
+		"operation": "UPDATE",
+		"userInfo": {
+			"username": "minikube-user",
+			"groups": [
+				"system:masters",
+				"system:authenticated",
+			],
+		},
+		"object": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"frens.teq0.com/v1\",\"kind\":\"Dog\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar1\"},\"name\":\"rex\",\"namespace\":\"\"},\"spec\":{\"food\":\"meat\",\"isGood\":false,\"name\":\"Rex\"}}\n"},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"labels": {"foo": "bar1"},
+				"name": "rex",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": false,
+				"name": "Rex",
+			},
+		},
+		"oldObject": {
+			"apiVersion": "frens.teq0.com/v1",
+			"kind": "Dog",
+			"metadata": {
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"frens.teq0.com/v1\",\"kind\":\"Dog\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar1\"},\"name\":\"rex\",\"namespace\":\"\"},\"spec\":{\"food\":\"meat\",\"isGood\":false,\"name\":\"Rex\"}}\n"},
+				"creationTimestamp": "2018-12-26T02:36:30Z",
+				"generation": 1,
+				"labels": {"foo1": "bar1"},
+				"name": "rex",
+				"resourceVersion": "61919",
+				"uid": "0d0f9b6a-08b7-11e9-9a47-080027f60d22",
+			},
+			"spec": {
+				"food": "meat",
+				"isGood": false,
+				"name": "Rex",
+			},
+		},
+		"dryRun": false,
+	},
+}
+
+# Simple sub-objects for testing the helper functions
+object_with_label_foo_bar = {"metadata": {"labels": {"foo": "bar"}}}
+
+object_without_labels = {"metadata": {"annotations": {"foo": "bar"}}}
+
+object_with_annotation_foo_bar = {"metadata": {"annotations": {"foo": "bar"}}}
+
+object_without_annotations = {"metadata": {"labels": {"foo": "bar"}}}
+
+object_without_labels_or_annotations = {"metadata": {}}
+
+# Standard K8s Deployment requests
+
+request_deployment_no_versions = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {
+		"uid": "7916f3dc-1393-11e9-8ef2-080027da5735",
+		"kind": {
+			"group": "extensions",
+			"version": "v1beta1",
+			"kind": "Deployment",
+		},
+		"resource": {
+			"group": "extensions",
+			"version": "v1beta1",
+			"resource": "deployments",
+		},
+		"namespace": "default",
+		"operation": "CREATE",
+		"userInfo": {
+			"username": "minikube-user",
+			"groups": [
+				"system:masters",
+				"system:authenticated",
+			],
+		},
+		"object": {
+			"metadata": {
+				"name": "deployment-demo-bad-no-version",
+				"namespace": "default",
+				"creationTimestamp": null,
+				"labels": {
+					"demo": "deployment",
+					"version": "v1",
+				},
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"deployment-demo-bad-no-version\",\"namespace\":\"default\"},\"spec\":{\"replicas\":2,\"selector\":{\"matchLabels\":{\"demo\":\"deployment\"}},\"strategy\":{\"rollingUpdate\":{\"maxSurge\":1,\"maxUnavailable\":0},\"type\":\"RollingUpdate\"},\"template\":{\"metadata\":{\"labels\":{\"demo\":\"deployment\",\"version\":\"v1\"}},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"while true; do echo $(hostname) v1 \\u003e /data/index.html; sleep 60; done\"],\"image\":\"busybox\",\"name\":\"busybox\",\"volumeMounts\":[{\"mountPath\":\"/data\",\"name\":\"content\"}]},{\"image\":\"nginx\",\"name\":\"nginx\",\"volumeMounts\":[{\"mountPath\":\"/usr/share/nginx/html\",\"name\":\"content\",\"readOnly\":true}]}],\"volumes\":[{\"name\":\"content\"}]}}}}\n"},
+			},
+			"spec": {
+				"replicas": 2,
+				"selector": {"matchLabels": {"demo": "deployment"}},
+				"template": {
+					"metadata": {
+						"creationTimestamp": null,
+						"labels": {
+							"demo": "deployment",
+							"version": "v1",
+						},
+					},
+					"spec": {
+						"volumes": [{
+							"name": "content",
+							"emptyDir": {},
+						}],
+						"containers": [
+							{
+								"name": "busybox",
+								"image": "busybox",
+								"command": [
+									"sh",
+									"-c",
+									"while true; do echo $(hostname) v1 > /data/index.html; sleep 60; done",
+								],
+								"resources": {},
+								"volumeMounts": [{
+									"name": "content",
+									"mountPath": "/data",
+								}],
+								"terminationMessagePath": "/dev/termination-log",
+								"terminationMessagePolicy": "File",
+								"imagePullPolicy": "Always",
+							},
+							{
+								"name": "nginx",
+								"image": "nginx",
+								"resources": {},
+								"volumeMounts": [{
+									"name": "content",
+									"readOnly": true,
+									"mountPath": "/usr/share/nginx/html",
+								}],
+								"terminationMessagePath": "/dev/termination-log",
+								"terminationMessagePolicy": "File",
+								"imagePullPolicy": "Always",
+							},
+						],
+						"restartPolicy": "Always",
+						"terminationGracePeriodSeconds": 30,
+						"dnsPolicy": "ClusterFirst",
+						"securityContext": {},
+						"schedulerName": "default-scheduler",
+					},
+				},
+				"strategy": {
+					"type": "RollingUpdate",
+					"rollingUpdate": {
+						"maxUnavailable": 0,
+						"maxSurge": 1,
+					},
+				},
+				"revisionHistoryLimit": 2147483647,
+				"progressDeadlineSeconds": 2147483647,
+			},
+			"status": {},
+		},
+		"oldObject": null,
+		"dryRun": false,
+	},
+}
+
+request_deployment_with_versions = {
+	"kind": "AdmissionReview",
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"request": {
+		"uid": "7916f3dc-1393-11e9-8ef2-080027da5735",
+		"kind": {
+			"group": "extensions",
+			"version": "v1beta1",
+			"kind": "Deployment",
+		},
+		"resource": {
+			"group": "extensions",
+			"version": "v1beta1",
+			"resource": "deployments",
+		},
+		"namespace": "default",
+		"operation": "CREATE",
+		"userInfo": {
+			"username": "minikube-user",
+			"groups": [
+				"system:masters",
+				"system:authenticated",
+			],
+		},
+		"object": {
+			"metadata": {
+				"name": "deployment-demo-bad-no-version",
+				"namespace": "default",
+				"creationTimestamp": null,
+				"labels": {
+					"demo": "deployment",
+					"version": "v1",
+				},
+				"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"deployment-demo-bad-no-version\",\"namespace\":\"default\"},\"spec\":{\"replicas\":2,\"selector\":{\"matchLabels\":{\"demo\":\"deployment\"}},\"strategy\":{\"rollingUpdate\":{\"maxSurge\":1,\"maxUnavailable\":0},\"type\":\"RollingUpdate\"},\"template\":{\"metadata\":{\"labels\":{\"demo\":\"deployment\",\"version\":\"v1\"}},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"while true; do echo $(hostname) v1 \\u003e /data/index.html; sleep 60; done\"],\"image\":\"busybox\",\"name\":\"busybox\",\"volumeMounts\":[{\"mountPath\":\"/data\",\"name\":\"content\"}]},{\"image\":\"nginx\",\"name\":\"nginx\",\"volumeMounts\":[{\"mountPath\":\"/usr/share/nginx/html\",\"name\":\"content\",\"readOnly\":true}]}],\"volumes\":[{\"name\":\"content\"}]}}}}\n"},
+			},
+			"spec": {
+				"replicas": 2,
+				"selector": {"matchLabels": {"demo": "deployment"}},
+				"template": {
+					"metadata": {
+						"creationTimestamp": null,
+						"labels": {
+							"demo": "deployment",
+							"version": "v1",
+						},
+					},
+					"spec": {
+						"volumes": [{
+							"name": "content",
+							"emptyDir": {},
+						}],
+						"containers": [
+							{
+								"name": "busybox",
+								"image": "busybox:1.30.0",
+								"command": [
+									"sh",
+									"-c",
+									"while true; do echo $(hostname) v1 > /data/index.html; sleep 60; done",
+								],
+								"resources": {},
+								"volumeMounts": [{
+									"name": "content",
+									"mountPath": "/data",
+								}],
+								"terminationMessagePath": "/dev/termination-log",
+								"terminationMessagePolicy": "File",
+								"imagePullPolicy": "Always",
+							},
+							{
+								"name": "nginx",
+								"image": "nginx:1.15.8",
+								"resources": {},
+								"volumeMounts": [{
+									"name": "content",
+									"readOnly": true,
+									"mountPath": "/usr/share/nginx/html",
+								}],
+								"terminationMessagePath": "/dev/termination-log",
+								"terminationMessagePolicy": "File",
+								"imagePullPolicy": "Always",
+							},
+						],
+						"restartPolicy": "Always",
+						"terminationGracePeriodSeconds": 30,
+						"dnsPolicy": "ClusterFirst",
+						"securityContext": {},
+						"schedulerName": "default-scheduler",
+					},
+				},
+				"strategy": {
+					"type": "RollingUpdate",
+					"rollingUpdate": {
+						"maxUnavailable": 0,
+						"maxSurge": 1,
+					},
+				},
+				"revisionHistoryLimit": 2147483647,
+				"progressDeadlineSeconds": 2147483647,
+			},
+			"status": {},
+		},
+		"oldObject": null,
+		"dryRun": false,
+	},
+}

--- a/kubernetes/mutating-admission/example_mutation.rego
+++ b/kubernetes/mutating-admission/example_mutation.rego
@@ -11,7 +11,7 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	not hasLabelValue[["foo", "bar"]] with input as input.request.object
+	not hasLabelValue("foo", "bar") with input as input.request.object
 	patchCode = makeLabelPatch("add", "foo", "bar", "")
 }
 
@@ -20,8 +20,8 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	hasLabelValue[["foo", "bar"]] with input as input.request.object
-	not hasLabelValue[["baz", "quux"]] with input as input.request.object
+	hasLabelValue("foo", "bar") with input as input.request.object
+	not hasLabelValue("baz", "quux") with input as input.request.object
 	patchCode = makeLabelPatch("add", "baz", "quux", "")
 }
 
@@ -30,7 +30,7 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	hasLabelValue[["moar-labels", "pleez"]] with input as input.request.object
+	hasLabelValue("moar-labels", "pleez") with input as input.request.object
 	patchCode = makeLabelPatch("add", "quuz", "corge", "")
 }
 
@@ -39,6 +39,6 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	not hasAnnotation.rating with input as input.request.object
+	not hasAnnotation("rating") with input as input.request.object
 	patchCode = makeAnnotationPatch("add", "rating", "14/10", "")
 }

--- a/kubernetes/mutating-admission/example_mutation.rego
+++ b/kubernetes/mutating-admission/example_mutation.rego
@@ -1,0 +1,44 @@
+package library.kubernetes.admission.mutating
+
+############################################################
+# PATCH rules 
+#
+# Note: All patch rules should start with `isValidRequest` and `isCreateOrUpdate`
+############################################################
+
+# add foo label to Dogs if not present
+patch[patchCode] {
+	isValidRequest
+	isCreateOrUpdate
+	input.request.kind.kind == "Dog"
+	not hasLabelValue[["foo", "bar"]] with input as input.request.object
+	patchCode = makeLabelPatch("add", "foo", "bar", "")
+}
+
+# add baz label if it has label foo=bar
+patch[patchCode] {
+	isValidRequest
+	isCreateOrUpdate
+	input.request.kind.kind == "Dog"
+	hasLabelValue[["foo", "bar"]] with input as input.request.object
+	not hasLabelValue[["baz", "quux"]] with input as input.request.object
+	patchCode = makeLabelPatch("add", "baz", "quux", "")
+}
+
+# add quuz label to Dogs if it's asking
+patch[patchCode] {
+	isValidRequest
+	isCreateOrUpdate
+	input.request.kind.kind == "Dog"
+	hasLabelValue[["moar-labels", "pleez"]] with input as input.request.object
+	patchCode = makeLabelPatch("add", "quuz", "corge", "")
+}
+
+# Dogs get a rating
+patch[patchCode] {
+	isValidRequest
+	isCreateOrUpdate
+	input.request.kind.kind == "Dog"
+	not hasAnnotation.rating with input as input.request.object
+	patchCode = makeAnnotationPatch("add", "rating", "14/10", "")
+}

--- a/kubernetes/mutating-admission/example_validation.rego
+++ b/kubernetes/mutating-admission/example_validation.rego
@@ -1,0 +1,31 @@
+package library.kubernetes.admission.mutating
+
+############################################################
+# DENY rules 
+############################################################
+
+# Check for bad dogs
+deny[msg] {
+	isCreateOrUpdate
+	input.request.kind.kind = "Dog"
+	input.request.object.spec.isGood = false
+	msg = sprintf("%s is a good dog, Brent", [input.request.object.spec.name])
+}
+
+# Don't allow container images with no version tag, or a version tag that doesn't contain at least one digit
+
+missingImageVersion(imageName) {
+	not re_match(`.*:.*\d.*$`, imageName)
+}
+
+deny[msg] {
+	input.request.kind.kind = "Deployment"
+	badImages = {image |
+		image = input.request.object.spec.template.spec.containers[_].image
+		missingImageVersion(image, true)
+	}
+
+	count(badImages) > 0
+	names = concat(", ", badImages)
+	msg = sprintf("Container images must specify a version (%s)", [names])
+}

--- a/kubernetes/mutating-admission/main.rego
+++ b/kubernetes/mutating-admission/main.rego
@@ -71,9 +71,9 @@ isUpdate {
 # can apply to various sub-objects within a request
 # So from the context of an AdmissionRequest they need to
 # be called like
-#   hasLabelValue[["foo", "bar"]] with input as input.request.object
+#   hasLabelValue("foo", "bar") with input as input.request.object
 # or
-#   hasLabelValue[["foo", "bar"]] with input as input.request.oldObject
+#   hasLabelValue("foo", "bar") with input as input.request.oldObject
 ###########################################################################
 
 hasLabels {

--- a/kubernetes/mutating-admission/main.rego
+++ b/kubernetes/mutating-admission/main.rego
@@ -80,13 +80,11 @@ hasLabels {
 	input.metadata.labels
 }
 
-hasLabel[label] {
-	hasLabels
+hasLabel(label) {
 	input.metadata.labels[label]
 }
 
-hasLabelValue[[key, val]] {
-	hasLabels
+hasLabelValue(key, val) {
 	input.metadata.labels[key] = val
 }
 
@@ -94,13 +92,11 @@ hasAnnotations {
 	input.metadata.annotations
 }
 
-hasAnnotation[annotation] {
-	hasAnnotations
+hasAnnotation(annotation) {
 	input.metadata.annotations[annotation]
 }
 
-hasAnnotationValue[[key, val]] {
-	hasAnnotations
+hasAnnotationValue(key, val) {
 	input.metadata.annotations[key] = val
 }
 

--- a/kubernetes/mutating-admission/main.rego
+++ b/kubernetes/mutating-admission/main.rego
@@ -1,0 +1,179 @@
+package library.kubernetes.admission.mutating
+
+###########################################################################
+# Implementation of the k8s admission control external webhook interface,
+# combining validating and mutating admission controllers
+###########################################################################
+
+main = {
+	"apiVersion": "admission.k8s.io/v1beta1",
+	"kind": "AdmissionReview",
+	"response": response,
+}
+
+default response = {"allowed": true}
+
+# non-patch response i.e. validation response
+response = x {
+	count(patch) = 0
+
+	x := {
+		"allowed": false,
+		"status": {"reason": reason},
+	}
+
+	reason = concat(", ", deny)
+	reason != ""
+}
+
+# patch response i.e. mutating respone
+response = x {
+	count(patch) > 0
+
+	# if there are missing leaves e.g. trying to add a label to something that doesn't
+	# yet have any, we need to create the leaf nodes as well
+
+	fullPatches := ensureParentPathsExist(cast_array(patch))
+
+	x := {
+		"allowed": true,
+		"patchType": "JSONPatch",
+		"patch": base64url.encode(json.marshal(fullPatches)),
+	}
+}
+
+isValidRequest {
+	# not sure if this might be a race condition, it might get called before 
+	# all the validation rules have been run
+	count(deny) = 0
+}
+
+isCreateOrUpdate {
+	isCreate
+}
+
+isCreateOrUpdate {
+	isUpdate
+}
+
+isCreate {
+	input.request.operation == "CREATE"
+}
+
+isUpdate {
+	input.request.operation == "UPDATE"
+}
+
+###########################################################################
+# PATCH helpers 
+# Note: These rules assume that the input is an object
+# not an AdmissionRequest, because labels and annotations 
+# can apply to various sub-objects within a request
+# So from the context of an AdmissionRequest they need to
+# be called like
+#   hasLabelValue[["foo", "bar"]] with input as input.request.object
+# or
+#   hasLabelValue[["foo", "bar"]] with input as input.request.oldObject
+###########################################################################
+
+hasLabels {
+	input.metadata.labels
+}
+
+hasLabel[label] {
+	hasLabels
+	input.metadata.labels[label]
+}
+
+hasLabelValue[[key, val]] {
+	hasLabels
+	input.metadata.labels[key] = val
+}
+
+hasAnnotations {
+	input.metadata.annotations
+}
+
+hasAnnotation[annotation] {
+	hasAnnotations
+	input.metadata.annotations[annotation]
+}
+
+hasAnnotationValue[[key, val]] {
+	hasAnnotations
+	input.metadata.annotations[key] = val
+}
+
+###########################################################################
+# makeLabelPatch creates a label patch
+# Labels can exist on numerous child objects e.g. Deployment.template.metadata
+# Use pathPrefix to specify a lower level object, or pass "" to select the 
+# top level object
+# Note: pathPrefix should have a leading '/' but no trailing '/'
+###########################################################################
+
+makeLabelPatch(op, key, value, pathPrefix) = patchCode {
+	patchCode = {
+		"op": op,
+		"path": concat("/", [pathPrefix, "metadata/labels", key]),
+		"value": value,
+	}
+}
+
+makeAnnotationPatch(op, key, value, pathPrefix) = patchCode {
+	patchCode = {
+		"op": op,
+		"path": concat("/", [pathPrefix, "metadata/annotations", key]),
+		"value": value,
+	}
+}
+
+# Given array of JSON patches create and prepend new patches that create missing paths.
+ensureParentPathsExist(patches) = result {
+	paths := {p.path | p := patches[_]}
+	newPatches := {makePath(prefixArray) |
+		paths[path]
+		fullLength := count(path)
+		pathArray := split(path, "/")
+
+		# Need a slice of the path_array with all but the last element.
+		# No way to do that with arrays, but we can do it with strings.
+		arrayLength := count(pathArray)
+		lastElementLength := count(pathArray[minus(arrayLength, 1)])
+
+		# this assumes paths starts with '/'
+		prefixPath := substring(path, 1, (fullLength - lastElementLength) - 2)
+		prefixArray := split(prefixPath, "/")
+		not inputPathExists(prefixArray) with input as input.request.object
+	}
+
+	result := array.concat(cast_array(newPatches), patches)
+}
+
+# Create the JSON patch to ensure the @path_array exists
+makePath(pathArray) = result {
+	pathStr := concat("/", array.concat([""], pathArray))
+
+	result = {
+		"op": "add",
+		"path": pathStr,
+		"value": {},
+	}
+}
+
+# Check that the given @path exists as part of the input object.
+inputPathExists(path) {
+	walk(input, [path, _])
+}
+
+# Dummy deny and patch to please the compiler
+
+deny[msg] {
+	input.request.kind == "AdmissionReview"
+	msg = "Input must be Kubernetes AdmissionRequest"
+}
+
+patch[patchCode] {
+	input.kind == "ThisHadBetterNotBeARealKind"
+	patchCode = {}
+}

--- a/kubernetes/mutating-admission/test_mutation.rego
+++ b/kubernetes/mutating-admission/test_mutation.rego
@@ -24,21 +24,21 @@ test_no_labels_true {
 # Test: hasLabel is true when the label exists
 #-----------------------------------------------------------
 test_hasLabel_foo {
-	hasLabel.foo with input as k8s.object_with_label_foo_bar
+	hasLabel("foo") with input as k8s.object_with_label_foo_bar
 }
 
 #-----------------------------------------------------------
 # Test: hasLabel is false when the label doesn't exist
 #-----------------------------------------------------------
 test_not_hasLabel_foo1 {
-	not hasLabel.foo1 with input as k8s.object_with_label_foo_bar
+	not hasLabel("foo1") with input as k8s.object_with_label_foo_bar
 }
 
 #-----------------------------------------------------------
 # Test: hasLabelValue is true when the label has the correct value
 #-----------------------------------------------------------
 test_hasLabelValue_fooeqbar {
-	hasLabelValue[["foo", "bar"]] with input as k8s.object_with_label_foo_bar
+	hasLabelValue("foo", "bar") with input as k8s.object_with_label_foo_bar
 }
 
 #-----------------------------------------------------------
@@ -59,21 +59,21 @@ test_no_annotations_true {
 # Test: hasAnnotation is true when the annotation exists
 #-----------------------------------------------------------
 test_hasAnnotation_foo {
-	hasAnnotation.foo with input as k8s.object_with_annotation_foo_bar
+	hasAnnotation("foo") with input as k8s.object_with_annotation_foo_bar
 }
 
 #-----------------------------------------------------------
 # Test: hasAnnotation is false when the annotation doesn't exist
 #-----------------------------------------------------------
 test_not_hasAnnotation_foo1 {
-	not hasAnnotation.foo1 with input as k8s.object_with_annotation_foo_bar
+	not hasAnnotation("foo1") with input as k8s.object_with_annotation_foo_bar
 }
 
 #-----------------------------------------------------------
 # Test: hasAnnotationValue is true when the annotation has the correct value
 #-----------------------------------------------------------
 test_hasAnnotation_fooeqbar {
-	hasAnnotationValue[["foo", "bar"]] with input as k8s.object_with_annotation_foo_bar
+	hasAnnotationValue("foo", "bar") with input as k8s.object_with_annotation_foo_bar
 }
 
 #-----------------------------------------------------------
@@ -83,7 +83,7 @@ test_makeLabelPatch {
 	l := makeLabelPatch("add", "foo", "bar", "") with input as k8s.object_with_label_foo_bar
 	l = {"op": "add", "path": "/metadata/labels/foo", "value": "bar"}
 
-	# test pathPrefix
+	# test pathPrefix e.g. if the label is on the Pod template in a Deployment
 	m := makeLabelPatch("add", "foo", "bar", "/spec/template") with input as k8s.object_with_label_foo_bar
 	m = {"op": "add", "path": "/spec/template/metadata/labels/foo", "value": "bar"}
 }

--- a/kubernetes/mutating-admission/test_mutation.rego
+++ b/kubernetes/mutating-admission/test_mutation.rego
@@ -1,0 +1,239 @@
+package library.kubernetes.admission.mutating
+
+import data.library.kubernetes.admission.mutating.test as k8s
+
+############################################################
+# PATCH helper tests 
+############################################################
+
+#-----------------------------------------------------------
+# Test: hasLabels is true when there are labels
+#-----------------------------------------------------------
+test_hasLabels_true {
+	hasLabels with input as k8s.object_with_label_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: hasLabels is false when there are no labels
+#-----------------------------------------------------------
+test_no_labels_true {
+	not hasLabels with input as k8s.object_without_labels
+}
+
+#-----------------------------------------------------------
+# Test: hasLabel is true when the label exists
+#-----------------------------------------------------------
+test_hasLabel_foo {
+	hasLabel.foo with input as k8s.object_with_label_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: hasLabel is false when the label doesn't exist
+#-----------------------------------------------------------
+test_not_hasLabel_foo1 {
+	not hasLabel.foo1 with input as k8s.object_with_label_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: hasLabelValue is true when the label has the correct value
+#-----------------------------------------------------------
+test_hasLabelValue_fooeqbar {
+	hasLabelValue[["foo", "bar"]] with input as k8s.object_with_label_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: hasAnnotations is true when there are annotations
+#-----------------------------------------------------------
+test_hasAnnotations_true {
+	hasAnnotations with input as k8s.object_with_annotation_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: hasAnnotations is false when there are no annotations
+#-----------------------------------------------------------
+test_no_annotations_true {
+	not hasAnnotations with input as k8s.object_without_annotations
+}
+
+#-----------------------------------------------------------
+# Test: hasAnnotation is true when the annotation exists
+#-----------------------------------------------------------
+test_hasAnnotation_foo {
+	hasAnnotation.foo with input as k8s.object_with_annotation_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: hasAnnotation is false when the annotation doesn't exist
+#-----------------------------------------------------------
+test_not_hasAnnotation_foo1 {
+	not hasAnnotation.foo1 with input as k8s.object_with_annotation_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: hasAnnotationValue is true when the annotation has the correct value
+#-----------------------------------------------------------
+test_hasAnnotation_fooeqbar {
+	hasAnnotationValue[["foo", "bar"]] with input as k8s.object_with_annotation_foo_bar
+}
+
+#-----------------------------------------------------------
+# Test: makeLabelPatch creates a valid patch
+#-----------------------------------------------------------
+test_makeLabelPatch {
+	l := makeLabelPatch("add", "foo", "bar", "") with input as k8s.object_with_label_foo_bar
+	l = {"op": "add", "path": "/metadata/labels/foo", "value": "bar"}
+
+	# test pathPrefix
+	m := makeLabelPatch("add", "foo", "bar", "/spec/template") with input as k8s.object_with_label_foo_bar
+	m = {"op": "add", "path": "/spec/template/metadata/labels/foo", "value": "bar"}
+}
+
+############################################################
+# PATCH tests 
+############################################################
+
+#-----------------------------------------------------------
+# Sample patch values to test against
+#-----------------------------------------------------------
+patchCode_labels_base = {
+	"op": "add",
+	"path": "/metadata/labels",
+	"value": {},
+}
+
+patchCode_label_foobar = {
+	"op": "add",
+	"path": "/metadata/labels/foo",
+	"value": "bar",
+}
+
+patchCode_label_bazquux = {
+	"op": "add",
+	"path": "/metadata/labels/baz",
+	"value": "quux",
+}
+
+patchCode_label_quuzcorge = {
+	"op": "add",
+	"path": "/metadata/labels/quuz",
+	"value": "corge",
+}
+
+patchCode_annotations_base = {
+	"op": "add",
+	"path": "/metadata/annotations",
+	"value": {},
+}
+
+patchCode_annotation_rating = {
+	"op": "add",
+	"path": "/metadata/annotations/rating",
+	"value": "14/10",
+}
+
+hasPatch(patches, patch) {
+	patches[_] = patch
+}
+
+isPatchResponse(res) {
+	res.response.patchType = "JSONPatch"
+	res.response.patch
+}
+
+#-----------------------------------------------------------
+# Test: patches are created for Dogs with no labels
+#-----------------------------------------------------------
+test_main_dog_no_labels_or_annotations {
+	res := main with input as k8s.request_dog_no_labels_or_annotations
+	res.response.allowed = true
+	isPatchResponse(res)
+	patches = json.unmarshal(base64url.decode(res.response.patch))
+	trace(sprintf("[test_main_dog_no_labels] patches = '%s'", [patches]))
+	hasPatch(patches, patchCode_labels_base)
+	hasPatch(patches, patchCode_label_foobar)
+	hasPatch(patches, patchCode_annotations_base)
+	hasPatch(patches, patchCode_annotation_rating)
+}
+
+#-----------------------------------------------------------
+# Test: patches are created for Dogs with existing labels but not foo
+#-----------------------------------------------------------
+test_main_dog_some_labels {
+	res := main with input as k8s.request_dog_some_labels_and_annotations
+	res.response.allowed = true
+	isPatchResponse(res)
+	patches = json.unmarshal(base64url.decode(res.response.patch))
+	trace(sprintf("[test_main_dog_some_labels] patches = '%s'", [patches]))
+	not hasPatch(patches, patchCode_labels_base)
+	hasPatch(patches, patchCode_label_foobar)
+	not hasPatch(patches, patchCode_annotations_base)
+	hasPatch(patches, patchCode_annotation_rating)
+}
+
+#-----------------------------------------------------------
+# Test: patches are not created for Dogs with existing labels foo and quuz and annotation rating
+# We need to test for either no patches at all are created, or
+# if some other rule creates some patches, it's not trying to 
+# add any that already exist
+#-----------------------------------------------------------
+test_main_dog_existing_labels_and_annotations {
+	res := main with input as k8s.request_dog_existing_labels_and_annotations
+	trace(sprintf("[test_main_dog_existing_labels_and_annotations] res = '%s'", [res]))
+	res.response.allowed = true
+	t_main_dog_existing_labels_and_annotations_detail with input as res
+}
+
+t_main_dog_existing_labels_and_annotations_detail {
+	not input.response.patchType
+	trace("[t_main_dog_existing_labels_and_annotations] patchType not set")
+}
+
+t_main_dog_existing_labels_and_annotations_detail {
+	input.response.patchType = "JSONPatch"
+	input.response.patch
+	patches = json.unmarshal(base64url.decode(input.response.patch))
+	trace(sprintf("[t_main_dog_existing_labels_and_annotations] patches = '%s'", [patches]))
+	not hasPatch(patches, patchCode_labels_base)
+	not hasPatch(patches, patchCode_label_foobar)
+	not hasPatch(patches, patchCode_label_quuzcorge)
+	not hasPatch(patches, patchCode_annotations_base)
+	not hasPatch(patches, patchCode_annotation_rating)
+}
+
+#-----------------------------------------------------------
+# Test: patches are created for Dogs wanting more labels
+#-----------------------------------------------------------
+test_main_dog_missing_label_quuzcorge {
+	res := main with input as k8s.request_dog_some_labels_and_annotations
+	res.response.allowed = true
+	res.response.patchType = "JSONPatch"
+	patches = json.unmarshal(base64url.decode(res.response.patch))
+	trace(sprintf("[test_main_dog_good_missing_label_quuzcorge] patches = '%s'", [patches]))
+	hasPatch(patches, patchCode_label_quuzcorge)
+}
+
+#-----------------------------------------------------------
+# Test: patches are created for Dogs with no anotations
+#-----------------------------------------------------------
+test_main_dog_add_first_annotation {
+	res := main with input as k8s.request_dog_no_labels_or_annotations
+	res.response.allowed = true
+	res.response.patchType = "JSONPatch"
+	patches = json.unmarshal(base64url.decode(res.response.patch))
+	trace(sprintf("[test_main_dog_add_first_annotation] patches = '%s'", [patches]))
+	hasPatch(patches, patchCode_annotations_base)
+	hasPatch(patches, patchCode_annotation_rating)
+}
+
+#-----------------------------------------------------------
+# Test: patches are created for Dogs with existing annotation
+#-----------------------------------------------------------
+test_main_dog_add_subsequent_annotation {
+	res := main with input as k8s.request_dog_some_labels_and_annotations
+	res.response.allowed = true
+	res.response.patchType = "JSONPatch"
+	patches = json.unmarshal(base64url.decode(res.response.patch))
+	trace(sprintf("[test_main_dog_add_subsequent_annotation] patches = '%s'", [patches]))
+	not hasPatch(patches, patchCode_annotations_base)
+	hasPatch(patches, patchCode_annotation_rating)
+}

--- a/kubernetes/mutating-admission/test_validation.rego
+++ b/kubernetes/mutating-admission/test_validation.rego
@@ -1,0 +1,48 @@
+package library.kubernetes.admission.mutating
+
+import data.library.kubernetes.admission.mutating.test as k8s
+
+############################################################
+# DENY tests 
+############################################################
+
+#-----------------------------------------------------------
+# Test: the default validation rule is ALLOW
+#-----------------------------------------------------------
+test_main_default_allow {
+	res := main with input as k8s.request_default
+	res.response.allowed
+}
+
+#-----------------------------------------------------------
+# Test: Dogs with isGood = true are allowed
+#-----------------------------------------------------------
+test_main_dog_good_allow {
+	res := main with input as k8s.request_dog_good
+	res.response.allowed = true
+}
+
+#-----------------------------------------------------------
+# Test: Dogs with isGood = false are rejected (They're good dogs, Brent)
+#-----------------------------------------------------------
+test_main_dog_bad_deny {
+	res := main with input as k8s.request_dog_bad
+	res.response.allowed = false
+}
+
+#-----------------------------------------------------------
+# Test: Deployment container images must have version tags
+#-----------------------------------------------------------
+test_container_images_must_have_versions {
+	res := main with input as k8s.request_deployment_no_versions
+	trace(sprintf("[test_container_images_must_have_versions] msg = %s", [res.response.status.reason]))
+	res.response.allowed = false
+}
+
+#-----------------------------------------------------------
+# Test: Deployment container images with valid version tags are allowed
+#-----------------------------------------------------------
+test_container_images_with_versions_are_allowed {
+	res := main with input as k8s.request_deployment_with_versions
+	res.response.allowed = true
+}


### PR DESCRIPTION
It includes a set of helper functions for manipulating labels and
annotations.

Related to issue #943, but isn't a full tutorial.