### PR TITLE
Refactor label/annotation helpers further

### DIFF
--- a/kubernetes/mutating-admission/README.md
+++ b/kubernetes/mutating-admission/README.md
@@ -10,4 +10,4 @@ When adding a label or annotation to some object's metadata Kubernetes requires 
 
 ## Helper functions
 
-A common use case for mutating admission controllers is adding or modifying labels and annotations, so a small set of helper functions is provided to aid readability. See `example_mutation.reg` for some examples.
+A common use case for mutating admission controllers is adding or modifying labels and annotations, so a small set of helper functions is provided to aid readability. See `example_mutation.rego` for some examples.

--- a/kubernetes/mutating-admission/example_mutation.rego
+++ b/kubernetes/mutating-admission/example_mutation.rego
@@ -11,7 +11,7 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	not hasLabelValue("foo", "bar") with input as input.request.object
+	not hasLabelValue(input.request.object, "foo", "bar")
 	patchCode = makeLabelPatch("add", "foo", "bar", "")
 }
 
@@ -20,8 +20,8 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	hasLabelValue("foo", "bar") with input as input.request.object
-	not hasLabelValue("baz", "quux") with input as input.request.object
+	hasLabelValue(input.request.object, "foo", "bar")
+	not hasLabelValue(input.request.object, "baz", "quux")
 	patchCode = makeLabelPatch("add", "baz", "quux", "")
 }
 
@@ -30,7 +30,7 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	hasLabelValue("moar-labels", "pleez") with input as input.request.object
+	hasLabelValue(input.request.object, "moar-labels", "pleez")
 	patchCode = makeLabelPatch("add", "quuz", "corge", "")
 }
 
@@ -39,6 +39,6 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	not hasAnnotation("rating") with input as input.request.object
+	not hasAnnotation(input.request.object, "rating")
 	patchCode = makeAnnotationPatch("add", "rating", "14/10", "")
 }

--- a/kubernetes/mutating-admission/main.rego
+++ b/kubernetes/mutating-admission/main.rego
@@ -76,28 +76,28 @@ isUpdate {
 #   hasLabelValue("foo", "bar") with input as input.request.oldObject
 ###########################################################################
 
-hasLabels {
-	input.metadata.labels
+hasLabels(obj) {
+	obj.metadata.labels
 }
 
-hasLabel(label) {
-	input.metadata.labels[label]
+hasLabel(obj, label) {
+	obj.metadata.labels[label]
 }
 
-hasLabelValue(key, val) {
-	input.metadata.labels[key] = val
+hasLabelValue(obj, key, val) {
+	obj.metadata.labels[key] = val
 }
 
-hasAnnotations {
-	input.metadata.annotations
+hasAnnotations(obj) {
+	obj.metadata.annotations
 }
 
-hasAnnotation(annotation) {
-	input.metadata.annotations[annotation]
+hasAnnotation(obj, annotation) {
+	obj.metadata.annotations[annotation]
 }
 
-hasAnnotationValue(key, val) {
-	input.metadata.annotations[key] = val
+hasAnnotationValue(obj, key, val) {
+	obj.metadata.annotations[key] = val
 }
 
 ###########################################################################

--- a/kubernetes/mutating-admission/test_mutation.rego
+++ b/kubernetes/mutating-admission/test_mutation.rego
@@ -10,70 +10,70 @@ import data.library.kubernetes.admission.mutating.test as k8s
 # Test: hasLabels is true when there are labels
 #-----------------------------------------------------------
 test_hasLabels_true {
-	hasLabels with input as k8s.object_with_label_foo_bar
+	hasLabels(k8s.object_with_label_foo_bar)
 }
 
 #-----------------------------------------------------------
 # Test: hasLabels is false when there are no labels
 #-----------------------------------------------------------
 test_no_labels_true {
-	not hasLabels with input as k8s.object_without_labels
+	not hasLabels(k8s.object_without_labels)
 }
 
 #-----------------------------------------------------------
 # Test: hasLabel is true when the label exists
 #-----------------------------------------------------------
 test_hasLabel_foo {
-	hasLabel("foo") with input as k8s.object_with_label_foo_bar
+	hasLabel(k8s.object_with_label_foo_bar, "foo")
 }
 
 #-----------------------------------------------------------
 # Test: hasLabel is false when the label doesn't exist
 #-----------------------------------------------------------
 test_not_hasLabel_foo1 {
-	not hasLabel("foo1") with input as k8s.object_with_label_foo_bar
+	not hasLabel(k8s.object_with_label_foo_bar, "foo1")
 }
 
 #-----------------------------------------------------------
 # Test: hasLabelValue is true when the label has the correct value
 #-----------------------------------------------------------
 test_hasLabelValue_fooeqbar {
-	hasLabelValue("foo", "bar") with input as k8s.object_with_label_foo_bar
+	hasLabelValue(k8s.object_with_label_foo_bar, "foo", "bar")
 }
 
 #-----------------------------------------------------------
 # Test: hasAnnotations is true when there are annotations
 #-----------------------------------------------------------
 test_hasAnnotations_true {
-	hasAnnotations with input as k8s.object_with_annotation_foo_bar
+	hasAnnotations(k8s.object_with_annotation_foo_bar)
 }
 
 #-----------------------------------------------------------
 # Test: hasAnnotations is false when there are no annotations
 #-----------------------------------------------------------
 test_no_annotations_true {
-	not hasAnnotations with input as k8s.object_without_annotations
+	not hasAnnotations(k8s.object_without_annotations)
 }
 
 #-----------------------------------------------------------
 # Test: hasAnnotation is true when the annotation exists
 #-----------------------------------------------------------
 test_hasAnnotation_foo {
-	hasAnnotation("foo") with input as k8s.object_with_annotation_foo_bar
+	hasAnnotation(k8s.object_with_annotation_foo_bar, "foo")
 }
 
 #-----------------------------------------------------------
 # Test: hasAnnotation is false when the annotation doesn't exist
 #-----------------------------------------------------------
 test_not_hasAnnotation_foo1 {
-	not hasAnnotation("foo1") with input as k8s.object_with_annotation_foo_bar
+	not hasAnnotation(k8s.object_with_annotation_foo_bar, "foo1")
 }
 
 #-----------------------------------------------------------
 # Test: hasAnnotationValue is true when the annotation has the correct value
 #-----------------------------------------------------------
 test_hasAnnotation_fooeqbar {
-	hasAnnotationValue("foo", "bar") with input as k8s.object_with_annotation_foo_bar
+	hasAnnotationValue(k8s.object_with_annotation_foo_bar, "foo", "bar")
 }
 
 #-----------------------------------------------------------


### PR DESCRIPTION
These changes refactor the label/annotation helpers to take the object
itself as input so that the with keyword doesn't have to be used.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>