### PR TITLE
Fixed issue #25, slashes in label and annotation keys.

### DIFF
--- a/kubernetes/mutating-admission/README.md
+++ b/kubernetes/mutating-admission/README.md
@@ -4,10 +4,16 @@
 
 It was based on the existing examples at [Kubernetes Admission Control](https://www.openpolicyagent.org/docs/kubernetes-admission-control.html) and [MutatingAdmissionWebhook Example with OPA](https://gist.github.com/tsandall/a9b2b57f7c6768f49b25271776b72dee).
 
-## A note about labels and annotationsd
+## A note about labels and annotations
 
 When adding a label or annotation to some object's metadata Kubernetes requires that the `.../metadata/labels` or `.../metadata/annotations` node exists. The patch framework manages this through the `ensureParentPathsExist()` function, which will create the base `labels` or `annotations` nodes where required.
 
 ## Helper functions
 
-A common use case for mutating admission controllers is adding or modifying labels and annotations, so a small set of helper functions is provided to aid readability. See `example_mutation.rego` for some examples.
+A common use case for mutating admission controllers is adding or modifying labels and annotations, so a small set of helper functions is provided to aid readability. See `example_mutation.rego` for some examples, and `test_mutation.rego` for examples of unit tests.
+
+Note that the `makeLabelPatch()` and `makeAnnotationPatch()` helper functions also handle the common case where labels or annotations may have a slash in the key name, for example `kubernetes.io/role`. This needs to be escaped to `kubernetes.io~1role`, and this is handled automatically in the helper functions.
+
+## Mutating vs Validating Admission Controllers
+
+Mutating Admission Controllers can also return `allowed=false` statuses, to deny the request. This can be handy in simple cases, but be aware that in this library the validation policies (the `deny` rules) will override any patches. In some use cases the mutations applied might be the thing that fixes up raw requests in order to pass validation (adding required labels, for example). In that case you would need to configure two separate OPA instances, one for validation and one for mutation, as Kubernetes will call any mutating controllers before calling any validating controllers.

--- a/kubernetes/mutating-admission/data_kubernetes.rego
+++ b/kubernetes/mutating-admission/data_kubernetes.rego
@@ -199,7 +199,7 @@ request_dog_existing_labels_and_annotations = {
 			"apiVersion": "frens.teq0.com/v1",
 			"kind": "Dog",
 			"metadata": {
-				"annotations": {"rating": "14/10"},
+				"annotations": {"dogs.io/rating": "14/10"},
 				"labels": {
 					"foo": "bar",
 					"quuz": "corge",

--- a/kubernetes/mutating-admission/example_mutation.rego
+++ b/kubernetes/mutating-admission/example_mutation.rego
@@ -39,6 +39,6 @@ patch[patchCode] {
 	isValidRequest
 	isCreateOrUpdate
 	input.request.kind.kind == "Dog"
-	not hasAnnotation(input.request.object, "rating")
-	patchCode = makeAnnotationPatch("add", "rating", "14/10", "")
+	not hasAnnotation(input.request.object, "dogs.io/rating")
+	patchCode = makeAnnotationPatch("add", "dogs.io/rating", "14/10", "")
 }

--- a/kubernetes/mutating-admission/main.rego
+++ b/kubernetes/mutating-admission/main.rego
@@ -38,7 +38,7 @@ response = x {
 	x := {
 		"allowed": true,
 		"patchType": "JSONPatch",
-		"patch": base64url.encode(json.marshal(fullPatches)),
+		"patch": base64.encode(json.marshal(fullPatches)),
 	}
 }
 
@@ -111,7 +111,7 @@ hasAnnotationValue(obj, key, val) {
 makeLabelPatch(op, key, value, pathPrefix) = patchCode {
 	patchCode = {
 		"op": op,
-		"path": concat("/", [pathPrefix, "metadata/labels", key]),
+		"path": concat("/", [pathPrefix, "metadata/labels", replace(key, "/", "~1")]),
 		"value": value,
 	}
 }
@@ -119,7 +119,7 @@ makeLabelPatch(op, key, value, pathPrefix) = patchCode {
 makeAnnotationPatch(op, key, value, pathPrefix) = patchCode {
 	patchCode = {
 		"op": op,
-		"path": concat("/", [pathPrefix, "metadata/annotations", key]),
+		"path": concat("/", [pathPrefix, "metadata/annotations", replace(key, "/", "~1")]),
 		"value": value,
 	}
 }

--- a/kubernetes/mutating-admission/test_mutation.rego
+++ b/kubernetes/mutating-admission/test_mutation.rego
@@ -127,7 +127,7 @@ patchCode_annotations_base = {
 
 patchCode_annotation_rating = {
 	"op": "add",
-	"path": "/metadata/annotations/rating",
+	"path": "/metadata/annotations/dogs.io~1rating",
 	"value": "14/10",
 }
 
@@ -147,7 +147,7 @@ test_main_dog_no_labels_or_annotations {
 	res := main with input as k8s.request_dog_no_labels_or_annotations
 	res.response.allowed = true
 	isPatchResponse(res)
-	patches = json.unmarshal(base64url.decode(res.response.patch))
+	patches = json.unmarshal(base64.decode(res.response.patch))
 	trace(sprintf("[test_main_dog_no_labels] patches = '%s'", [patches]))
 	hasPatch(patches, patchCode_labels_base)
 	hasPatch(patches, patchCode_label_foobar)
@@ -162,7 +162,7 @@ test_main_dog_some_labels {
 	res := main with input as k8s.request_dog_some_labels_and_annotations
 	res.response.allowed = true
 	isPatchResponse(res)
-	patches = json.unmarshal(base64url.decode(res.response.patch))
+	patches = json.unmarshal(base64.decode(res.response.patch))
 	trace(sprintf("[test_main_dog_some_labels] patches = '%s'", [patches]))
 	not hasPatch(patches, patchCode_labels_base)
 	hasPatch(patches, patchCode_label_foobar)
@@ -191,7 +191,7 @@ t_main_dog_existing_labels_and_annotations_detail {
 t_main_dog_existing_labels_and_annotations_detail {
 	input.response.patchType = "JSONPatch"
 	input.response.patch
-	patches = json.unmarshal(base64url.decode(input.response.patch))
+	patches = json.unmarshal(base64.decode(input.response.patch))
 	trace(sprintf("[t_main_dog_existing_labels_and_annotations] patches = '%s'", [patches]))
 	not hasPatch(patches, patchCode_labels_base)
 	not hasPatch(patches, patchCode_label_foobar)
@@ -207,7 +207,7 @@ test_main_dog_missing_label_quuzcorge {
 	res := main with input as k8s.request_dog_some_labels_and_annotations
 	res.response.allowed = true
 	res.response.patchType = "JSONPatch"
-	patches = json.unmarshal(base64url.decode(res.response.patch))
+	patches = json.unmarshal(base64.decode(res.response.patch))
 	trace(sprintf("[test_main_dog_good_missing_label_quuzcorge] patches = '%s'", [patches]))
 	hasPatch(patches, patchCode_label_quuzcorge)
 }
@@ -219,7 +219,7 @@ test_main_dog_add_first_annotation {
 	res := main with input as k8s.request_dog_no_labels_or_annotations
 	res.response.allowed = true
 	res.response.patchType = "JSONPatch"
-	patches = json.unmarshal(base64url.decode(res.response.patch))
+	patches = json.unmarshal(base64.decode(res.response.patch))
 	trace(sprintf("[test_main_dog_add_first_annotation] patches = '%s'", [patches]))
 	hasPatch(patches, patchCode_annotations_base)
 	hasPatch(patches, patchCode_annotation_rating)
@@ -232,7 +232,7 @@ test_main_dog_add_subsequent_annotation {
 	res := main with input as k8s.request_dog_some_labels_and_annotations
 	res.response.allowed = true
 	res.response.patchType = "JSONPatch"
-	patches = json.unmarshal(base64url.decode(res.response.patch))
+	patches = json.unmarshal(base64.decode(res.response.patch))
 	trace(sprintf("[test_main_dog_add_subsequent_annotation] patches = '%s'", [patches]))
 	not hasPatch(patches, patchCode_annotations_base)
 	hasPatch(patches, patchCode_annotation_rating)


### PR DESCRIPTION
Addresses https://github.com/open-policy-agent/library/issues/25.

Signed-off-by: teq0 <craig.hooper@gmail.com>