### PR TITLE
k8s mutation library: auto-create prefix patches

### DIFF
--- a/kubernetes/mutating-admission/main.rego
+++ b/kubernetes/mutating-admission/main.rego
@@ -128,26 +128,31 @@ makeAnnotationPatch(op, key, value, pathPrefix) = patchCode {
 ensureParentPathsExist(patches) = result {
 	# Convert patches to a set
 	paths := {p.path | p := patches[_]}
+
 	# Compute all missing subpaths.
 	#    Iterate over all paths and over all subpaths
 	#    If subpath doesn't exist, add it to the set after making it a string
 	missingPaths := {sprintf("/%s", [concat("/", prefixPath)]) |
 		paths[path]
 		pathArray := split(path, "/")
-		pathArray[i]  # walk over path
-		i > 0    # skip initial element
+		pathArray[i] # walk over path
+		i > 0 # skip initial element
+
 		# array of all elements in path up to i
-		prefixPath := [pathArray[j] | pathArray[j]; j < i; j > 0]  # j > 0: skip initial element
+		prefixPath := [pathArray[j] | pathArray[j]; j < i; j > 0] # j > 0: skip initial element
 		walkPath := [toWalkElement(x) | x := prefixPath[_]]
 		not inputPathExists(walkPath) with input as input.request.object
 	}
+
 	# Sort paths, to ensure they apply in correct order
 	ordered_paths := sort(missingPaths)
 
 	# Return new patches prepended to original patches.
 	#  Don't forget to prepend all paths with a /
 	new_patches := [{"op": "add", "path": p, "value": {}} |
-			         p := ordered_paths[_] ]
+		p := ordered_paths[_]
+	]
+
 	result := array.concat(new_patches, patches)
 }
 
@@ -159,6 +164,7 @@ inputPathExists(path) {
 toWalkElement(str) = str {
 	not re_match("^[0-9]+$", str)
 }
+
 toWalkElement(str) = x {
 	re_match("^[0-9]+$", str)
 	x := to_number(str)

--- a/kubernetes/mutating-admission/main.rego
+++ b/kubernetes/mutating-admission/main.rego
@@ -138,7 +138,8 @@ ensureParentPathsExist(patches) = result {
 		i > 0    # skip initial element
 		# array of all elements in path up to i
 		prefixPath := [pathArray[j] | pathArray[j]; j < i; j > 0]  # j > 0: skip initial element
-		not inputPathExists(prefixPath) with input as input.request.object
+		walkPath := [toWalkElement(x) | x := prefixPath[_]]
+		not inputPathExists(walkPath) with input as input.request.object
 	}
 	# Sort paths, to ensure they apply in correct order
 	ordered_paths := sort(missingPaths)
@@ -153,6 +154,14 @@ ensureParentPathsExist(patches) = result {
 # Check that the given @path exists as part of the input object.
 inputPathExists(path) {
 	walk(input, [path, _])
+}
+
+toWalkElement(str) = str {
+	not re_match("^[0-9]+$", str)
+}
+toWalkElement(str) = x {
+	re_match("^[0-9]+$", str)
+	x := to_number(str)
 }
 
 # Dummy deny and patch to please the compiler

--- a/kubernetes/mutating-admission/test_mutation.rego
+++ b/kubernetes/mutating-admission/test_mutation.rego
@@ -241,6 +241,16 @@ test_main_dog_add_subsequent_annotation {
 #-----------------------------------------------------------
 # Test: ensureParentPathsExist
 #-----------------------------------------------------------
+test_ensureParentPathsExist_array {
+	actual := ensureParentPathsExist([
+		{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"IfNotPresent"}
+	])
+	with input as {"request": {"object": {"spec": {"template": {"spec": {"containers": [{"foo": "bar"}]}}}}}}
+	correct := [
+		{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"IfNotPresent"}
+	]
+	actual == correct
+}
 test_ensureParentPathsExist_noop {
 	actual := ensureParentPathsExist([
 		{"op": "add", "path": "/metadata/labels/foo", "value": "bar"}

--- a/kubernetes/mutating-admission/test_mutation.rego
+++ b/kubernetes/mutating-admission/test_mutation.rego
@@ -242,62 +242,58 @@ test_main_dog_add_subsequent_annotation {
 # Test: ensureParentPathsExist
 #-----------------------------------------------------------
 test_ensureParentPathsExist_array {
-	actual := ensureParentPathsExist([
-		{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"IfNotPresent"}
-	])
-	with input as {"request": {"object": {"spec": {"template": {"spec": {"containers": [{"foo": "bar"}]}}}}}}
-	correct := [
-		{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"IfNotPresent"}
-	]
+	actual := ensureParentPathsExist([{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "IfNotPresent"}]) with input as {"request": {"object": {"spec": {"template": {"spec": {"containers": [{"foo": "bar"}]}}}}}}
+
+	correct := [{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "IfNotPresent"}]
+
 	actual == correct
 }
+
 test_ensureParentPathsExist_noop {
-	actual := ensureParentPathsExist([
-		{"op": "add", "path": "/metadata/labels/foo", "value": "bar"}
-		])
-		with input as k8s.request_dog_some_labels_and_annotations
-	correct := [
-		{"op": "add", "path": "/metadata/labels/foo", "value": "bar"}
-	]
+	actual := ensureParentPathsExist([{"op": "add", "path": "/metadata/labels/foo", "value": "bar"}]) with input as k8s.request_dog_some_labels_and_annotations
+
+	correct := [{"op": "add", "path": "/metadata/labels/foo", "value": "bar"}]
+
 	actual == correct
 }
 
 test_ensureParentPathsExist_noop_multi {
 	actual := ensureParentPathsExist([
 		{"op": "add", "path": "/metadata/labels/foo", "value": "bar"},
-		{"op": "add", "path": "/metadata/labels/bar", "value": "bar"}
-		])
-		with input as k8s.request_dog_some_labels_and_annotations
+		{"op": "add", "path": "/metadata/labels/bar", "value": "bar"},
+	]) with input as k8s.request_dog_some_labels_and_annotations
+
 	correct := [
 		{"op": "add", "path": "/metadata/labels/foo", "value": "bar"},
-		{"op": "add", "path": "/metadata/labels/bar", "value": "bar"}
+		{"op": "add", "path": "/metadata/labels/bar", "value": "bar"},
 	]
+
 	actual == correct
 }
 
 test_ensureParentPathsExist_simple {
-	actual := ensureParentPathsExist([
-		{"op": "add", "path": "/metadata/labels/foo/bar", "value": "baz"}
-		])
-		with input as k8s.request_dog_some_labels_and_annotations
+	actual := ensureParentPathsExist([{"op": "add", "path": "/metadata/labels/foo/bar", "value": "baz"}]) with input as k8s.request_dog_some_labels_and_annotations
+
 	correct := [
 		{"op": "add", "path": "/metadata/labels/foo", "value": {}},
-		{"op": "add", "path": "/metadata/labels/foo/bar", "value": "baz"}
+		{"op": "add", "path": "/metadata/labels/foo/bar", "value": "baz"},
 	]
+
 	actual == correct
 }
 
 test_ensureParentPathsExist_simple_multi {
 	actual := ensureParentPathsExist([
 		{"op": "add", "path": "/metadata/labels/foo/bar", "value": "baz"},
-		{"op": "add", "path": "/metadata/labels/foo/baz", "value": "baz"}
-		])
-		with input as k8s.request_dog_some_labels_and_annotations
+		{"op": "add", "path": "/metadata/labels/foo/baz", "value": "baz"},
+	]) with input as k8s.request_dog_some_labels_and_annotations
+
 	correct := [
 		{"op": "add", "path": "/metadata/labels/foo", "value": {}},
 		{"op": "add", "path": "/metadata/labels/foo/bar", "value": "baz"},
-		{"op": "add", "path": "/metadata/labels/foo/baz", "value": "baz"}
+		{"op": "add", "path": "/metadata/labels/foo/baz", "value": "baz"},
 	]
+
 	actual == correct
 }
 
@@ -308,9 +304,9 @@ test_ensureParentPathsExist_long_multi {
 		{"op": "add", "path": "/metadata/labels/foo/bar/baz/abc", "value": "def"},
 		{"op": "add", "path": "/metadata/labels/foo/bar/def", "value": "ghi"},
 		{"op": "add", "path": "/metadata/annot/foo/bar/def", "value": "ghi"},
-		{"op": "add", "path": "/root/foo/bar/def", "value": "ghi"}
-		])
-		with input as k8s.request_dog_some_labels_and_annotations
+		{"op": "add", "path": "/root/foo/bar/def", "value": "ghi"},
+	]) with input as k8s.request_dog_some_labels_and_annotations
+
 	correct := [
 		# new
 		{"op": "add", "path": "/metadata/annot", "value": {}},
@@ -328,8 +324,8 @@ test_ensureParentPathsExist_long_multi {
 		{"op": "add", "path": "/metadata/labels/foo/bar/baz/abc", "value": "def"},
 		{"op": "add", "path": "/metadata/labels/foo/bar/def", "value": "ghi"},
 		{"op": "add", "path": "/metadata/annot/foo/bar/def", "value": "ghi"},
-		{"op": "add", "path": "/root/foo/bar/def", "value": "ghi"}
+		{"op": "add", "path": "/root/foo/bar/def", "value": "ghi"},
 	]
+
 	actual == correct
 }
-


### PR DESCRIPTION
Previously, kubernetes mutating admission control policies
could specify a JSON patch for any path where at most
the parent of the key being mutated was missing.

This change allows the mutating admission control policies
to specify any JSON patch for an object, and any additional patches
for a key's parent or grandparent or grandgrandparent,
etc. will be automatically created.

Note: this change does not handle patches for arrays