### PR TITLE
add flux interval enforcement example

### DIFF
--- a/kubernetes/admission/example_fluxinterval.rego
+++ b/kubernetes/admission/example_fluxinterval.rego
@@ -5,29 +5,37 @@ package library.kubernetes.validating.fluxinterval
 image := "fluxcd/flux"
 
 deny[msg] {
+	some i
+
 	# Ensure only applies to flux images
-	containerImage := input.spec.template.spec.containers[i].image
-	contains(containerImage, image)
+	container := input.spec.template.spec.containers[i]
+	contains(container.image, image)
 
-	# Check if git poll interval arg is present
-	args := input.spec.template.spec.containers[_].args
-	contains(args[_], "--git-poll-interval")
+	some j
+	arg := container.args[j]
 
-	# If single digit is present, deny
-	regex.match("--git-poll-interval=[0-9]m", args[_])
+	# Extract interval argument value
+	interval := split(arg, "--git-poll-interval=")[1]
+
+	# Ensure values is not of seconds and is at least 2 digits with minutes
+	regex.match("^([0-9]{1,}s|[0-9]{1}m)$", interval)
 	msg := "--git-poll-interval must be at least 10m"
 }
 
 deny[msg] {
+	some i
+
 	# Ensure only applies to flux images
-	containerImage := input.spec.template.spec.containers[i].image
-	contains(containerImage, image)
+	container := input.spec.template.spec.containers[i]
+	contains(container.image, image)
 
-	# Check if sync interval arg is present
-	args := input.spec.template.spec.containers[_].args
-	contains(args[_], "--sync-interval")
+	some j
+	arg := container.args[j]
 
-	# If single digit is present, deny
-	regex.match("--sync-interval=[0-9]m", args[_])
+	# Extract interval argument value
+	interval := split(arg, "--sync-interval=")[1]
+
+	# Ensure values is not of seconds and is at least 2 digits with minutes
+	regex.match("^([0-9]{1,}s|[0-9]{1}m)$", interval)
 	msg := "--sync-interval must be at least 10m"
 }

--- a/kubernetes/admission/example_fluxinterval.rego
+++ b/kubernetes/admission/example_fluxinterval.rego
@@ -1,0 +1,33 @@
+# This example demonstrates how to ensure consumers of your kubernetes cluster don't slam
+# your cluster's API or git repositories by configuring [flux](https://fluxcd.io/) to sync too frequently.
+package library.kubernetes.validating.fluxinterval
+
+image := "fluxcd/flux"
+
+deny[msg] {
+	# Ensure only applies to flux images
+	containerImage := input.spec.template.spec.containers[i].image
+	contains(containerImage, image)
+
+	# Check if git poll interval arg is present
+	args := input.spec.template.spec.containers[_].args
+	contains(args[_], "--git-poll-interval")
+
+	# If single digit is present, deny
+	regex.match("--git-poll-interval=[0-9]m", args[_])
+	msg := "--git-poll-interval must be at least 10m"
+}
+
+deny[msg] {
+	# Ensure only applies to flux images
+	containerImage := input.spec.template.spec.containers[i].image
+	contains(containerImage, image)
+
+	# Check if sync interval arg is present
+	args := input.spec.template.spec.containers[_].args
+	contains(args[_], "--sync-interval")
+
+	# If single digit is present, deny
+	regex.match("--sync-interval=[0-9]m", args[_])
+	msg := "--sync-interval must be at least 10m"
+}

--- a/kubernetes/admission/example_loadbalancer.rego
+++ b/kubernetes/admission/example_loadbalancer.rego
@@ -10,7 +10,7 @@ deny[explanation] {
 	loadbalancer.is_external_lb
 	namespace := input.request.namespace
 	name := input.request.object.metadata.name
-	not whitelisted[{"namespace": namespace, "name": name}]
+	not whitelisted[{"name": name, "namespace": namespace}]
 	explanation = sprintf("Service %v/%v is an external load balancer but has not been whitelisted", [namespace, name])
 }
 

--- a/kubernetes/admission/test_fluxinterval.rego
+++ b/kubernetes/admission/test_fluxinterval.rego
@@ -12,10 +12,18 @@ test_five_minutes_denied {
 	deny with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=5m", "--sync-interval=5m"]}]}}}}
 }
 
+test_seconds_denied {
+	deny with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=1s", "--sync-interval=10s"]}]}}}}
+}
+
 test_five_minutes_denied_git_poll {
 	count(deny) == 1 with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=5m", "--sync-interval=10m"]}]}}}}
 }
 
 test_five_minutes_denied_sync_interval {
 	count(deny) == 1 with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=10m", "--sync-interval=5m"]}]}}}}
+}
+
+test_denied_multiple_containers {
+	count(deny) == 2 with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=10m", "--sync-interval=5m"]}, {"image": "fluxcd/flux:latest", "args": ["--git-poll-interval=1s"]}]}}}}
 }

--- a/kubernetes/admission/test_fluxinterval.rego
+++ b/kubernetes/admission/test_fluxinterval.rego
@@ -1,0 +1,21 @@
+package library.kubernetes.validating.fluxinterval
+
+test_ten_minutes_allowed {
+	count(deny) == 0 with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=10m", "--sync-interval=10m"]}]}}}}
+}
+
+test_one_hour_allowed {
+	count(deny) == 0 with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=1h", "--sync-interval=1h"]}]}}}}
+}
+
+test_five_minutes_denied {
+	deny with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=5m", "--sync-interval=5m"]}]}}}}
+}
+
+test_five_minutes_denied_git_poll {
+	count(deny) == 1 with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=5m", "--sync-interval=10m"]}]}}}}
+}
+
+test_five_minutes_denied_sync_interval {
+	count(deny) == 1 with input as {"spec": {"template": {"spec": {"containers": [{"image": "fluxcd/flux:1.20.2", "args": ["--git-poll-interval=10m", "--sync-interval=5m"]}]}}}}
+}


### PR DESCRIPTION
This example demonstrates how to ensure consumers of a kubernetes cluster don't slam a cluster's API or some git repositories by configuring [flux](https://fluxcd.io/) to sync too frequently. The example also shows how one would enforce argument values in a deployment spec.

Signed-off-by: circa10a <caleblemoine@gmail.com>